### PR TITLE
feature/Single page hash router with snap to section functionality.

### DIFF
--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 
+/**
+ * A page element to displayed via {@link HashRouter}
+ */
 export interface Page {
   content: React.ReactNode;
 }
@@ -8,6 +11,9 @@ type Props = {
   pages: Page[];
 };
 
+/**
+ * Render a single page router with snap to section functionality
+ */
 export default function HashRouter({ pages }: Props) {
   return (
     <main className="h-screen overflow-y-auto snap-y snap-mandatory">

--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export interface Page {
+  content: React.ReactNode;
+}
+
+type Props = {
+  pages: Page[];
+};
+
+export default function HashRouter({ pages }: Props) {
+  return (
+    <main className="h-screen overflow-y-auto snap-y snap-mandatory">
+      {pages.map((page, index) => (
+        <section key={index} className="snap-start">
+          {page.content}
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/src/components/hash-router/HashRouterDemo.tsx
+++ b/src/components/hash-router/HashRouterDemo.tsx
@@ -25,6 +25,9 @@ const pages: Page[] = [
   },
 ];
 
+/**
+ * Simple hash router demo with basic pages
+ */
 export default function HashRouterDemo() {
   return <HashRouter pages={pages} />;
 }

--- a/src/components/hash-router/HashRouterDemo.tsx
+++ b/src/components/hash-router/HashRouterDemo.tsx
@@ -1,5 +1,30 @@
 import React from "react";
+import HashRouter, { Page } from "./HashRouter";
+
+const pages: Page[] = [
+  {
+    content: (
+      <div className="h-screen bg-pink-700 text-white text-4xl p-10">
+        Same height as the screen
+      </div>
+    ),
+  },
+  {
+    content: (
+      <div className="h-[140vh] bg-violet-700 text-white text-4xl p-10">
+        Larger than the screen's height
+      </div>
+    ),
+  },
+  {
+    content: (
+      <div className="min-h-[55vh] bg-cyan-700 text-white text-4xl p-10">
+        Smaller than the screen's height
+      </div>
+    ),
+  },
+];
 
 export default function HashRouterDemo() {
-  return <div>Hash Router Demo</div>;
+  return <HashRouter pages={pages} />;
 }


### PR DESCRIPTION
Created a HashRouter component that snaps to the next/previous section while scrolling.

It is using [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) to snap to child elements on scroll. Each child is set to snap to the top via [scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align) property.

[HashRouter_spap_to_section.webm](https://user-images.githubusercontent.com/5620143/208554690-90e1cc9a-4cfc-4a64-9a92-e4622aef36be.webm)

