### PR TITLE
feature/Scroll to section based on window's hash

### DIFF
--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -6,7 +6,7 @@ import useHashIndex from "./useHashIndex";
  */
 export interface Page {
   /**
-   * string to link the page to the window's hash, without '#' character
+   * page's anchor for hash navigation, without '#' character
    */
   hash: string;
   content: React.ReactNode;

--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -1,9 +1,14 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import useHashIndex from "./useHashIndex";
 
 /**
  * A page element to displayed via {@link HashRouter}
  */
 export interface Page {
+  /**
+   * string to link the page to the window's hash, without '#' character
+   */
+  hash: string;
   content: React.ReactNode;
 }
 
@@ -15,8 +20,25 @@ type Props = {
  * Render a single page router with snap to section functionality
  */
 export default function HashRouter({ pages }: Props) {
+  const hashIndex = useHashIndex(pages);
+  const mainRef = useRef<HTMLElement>(null);
+
+  /**
+   * Scroll to section whose index = hashIndex when it changes
+   */
+  useEffect(
+    () =>
+      mainRef.current?.children[hashIndex].scrollIntoView({
+        behavior: "smooth",
+      }),
+    [hashIndex]
+  );
+
   return (
-    <main className="h-screen overflow-y-auto snap-y snap-mandatory">
+    <main
+      ref={mainRef}
+      className="h-screen overflow-y-auto snap-y snap-mandatory"
+    >
       {pages.map((page, index) => (
         <section key={index} className="snap-start">
           {page.content}

--- a/src/components/hash-router/HashRouterDemo.tsx
+++ b/src/components/hash-router/HashRouterDemo.tsx
@@ -3,6 +3,7 @@ import HashRouter, { Page } from "./HashRouter";
 
 const pages: Page[] = [
   {
+    hash: "intro",
     content: (
       <div className="h-screen bg-pink-700 text-white text-4xl p-10">
         Same height as the screen
@@ -10,6 +11,7 @@ const pages: Page[] = [
     ),
   },
   {
+    hash: "larger",
     content: (
       <div className="h-[140vh] bg-violet-700 text-white text-4xl p-10">
         Larger than the screen's height
@@ -17,6 +19,7 @@ const pages: Page[] = [
     ),
   },
   {
+    hash: "smaller",
     content: (
       <div className="min-h-[55vh] bg-cyan-700 text-white text-4xl p-10">
         Smaller than the screen's height

--- a/src/components/hash-router/useHashIndex.ts
+++ b/src/components/hash-router/useHashIndex.ts
@@ -1,0 +1,34 @@
+import { Page } from "./HashRouter";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Returns the stateful index of a page, whose hash field correlates with the browser's hash
+ */
+export default function useHashIndex(pages: Page[]): number {
+  /**
+   * Returns the index of the page whose hash = window.location.hash,
+   * 0 if no match is found
+   */
+  const getHashIndex = useCallback((): number => {
+    const hash = window.location.hash;
+    let hashIndex = pages.findIndex((page) => `#${page.hash}` === hash);
+    if (hashIndex < 0) {
+      hashIndex = 0;
+    }
+    return hashIndex;
+  }, [pages]);
+
+  const [hashIndex, setHashIndex] = useState(getHashIndex());
+
+  /**
+   * Register/remove a hashchange listener on mount/unmount
+   */
+  useEffect(() => {
+    const handleHashchange = () => setHashIndex(getHashIndex());
+
+    window.addEventListener("hashchange", handleHashchange);
+    return () => window.removeEventListener("hashchange", handleHashchange);
+  }, [getHashIndex]);
+
+  return hashIndex;
+}


### PR DESCRIPTION
- Added `hash` field to Page. It works as the page anchor for scroll navigation.
- Created useHashIndex hook. It watches window.location.hash changes and looks for the index of the page with the same hash.
- Whenever useHashIndex provides a new value, HashRouter scroll the view into the section with the same index.