### PR TITLE
feature/Change hash when scrolling between sections

### DIFF
--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import useHashIndex from "./useHashIndex";
+import Section from "./Section";
 
 /**
  * A page element to displayed via {@link HashRouter}
@@ -34,15 +35,24 @@ export default function HashRouter({ pages }: Props) {
     [hashIndex]
   );
 
+  function handleIntersect(index: number) {
+    if (index !== hashIndex) {
+      window.location.hash = pages[index].hash;
+    }
+  }
+
   return (
     <main
       ref={mainRef}
       className="h-screen overflow-y-auto snap-y snap-mandatory"
     >
       {pages.map((page, index) => (
-        <section key={index} className="snap-start">
-          {page.content}
-        </section>
+        <Section
+          key={index}
+          onIntersect={() => handleIntersect(index)}
+          page={page}
+          className="snap-start"
+        />
       ))}
     </main>
   );

--- a/src/components/hash-router/Section.tsx
+++ b/src/components/hash-router/Section.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from "react";
+import { Page } from "./HashRouter";
+import { useIntersect } from "./useIntersect";
+
+type Props = {
+  className?: string;
+  onIntersect: () => void;
+  page: Page;
+};
+
+/**
+ * Single {@link Page } section UI
+ * @param className optional class(es) to apply to the section
+ * @param onIntersect callback invoked when the section intersects with the viewport
+ * @param page element to display inside the section
+ */
+export default function Section({ className = "", onIntersect, page }: Props) {
+  const sectionRef = useRef(null);
+  const { intersecting, setIntersectTarget } = useIntersect(0.99);
+
+  /**
+   * Set section as intersecting target
+   */
+  useEffect(() => {
+    if (sectionRef.current) {
+      setIntersectTarget(sectionRef.current);
+    }
+  }, [setIntersectTarget]);
+
+  /**
+   * When section is intersecting, notify the parent
+   */
+  useEffect(() => {
+    if (intersecting) {
+      onIntersect();
+    }
+  }, [intersecting, onIntersect]);
+
+  return (
+    <section ref={sectionRef} className={className}>
+      {page.content}
+    </section>
+  );
+}

--- a/src/components/hash-router/useHashIndex.ts
+++ b/src/components/hash-router/useHashIndex.ts
@@ -1,34 +1,31 @@
 import { Page } from "./HashRouter";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Returns the stateful index of a page, whose hash field correlates with the browser's hash
  */
 export default function useHashIndex(pages: Page[]): number {
-  /**
-   * Returns the index of the page whose hash = window.location.hash,
-   * 0 if no match is found
-   */
-  const getHashIndex = useCallback((): number => {
-    const hash = window.location.hash;
-    let hashIndex = pages.findIndex((page) => `#${page.hash}` === hash);
-    if (hashIndex < 0) {
-      hashIndex = 0;
-    }
-    return hashIndex;
-  }, [pages]);
-
-  const [hashIndex, setHashIndex] = useState(getHashIndex());
+  const [hashIndex, setHashIndex] = useState(getHashIndex(pages));
 
   /**
    * Register/remove a hashchange listener on mount/unmount
    */
   useEffect(() => {
-    const handleHashchange = () => setHashIndex(getHashIndex());
+    const handleHashchange = () => setHashIndex(getHashIndex(pages));
 
     window.addEventListener("hashchange", handleHashchange);
     return () => window.removeEventListener("hashchange", handleHashchange);
-  }, [getHashIndex]);
+  }, [pages]);
 
   return hashIndex;
+}
+
+/**
+ * Returns the index of the page whose hash = window.location.hash, 0 if no match is found
+ * @param pages set of pages to search for a matching hash
+ */
+function getHashIndex(pages: Page[]) {
+  const hash = window.location.hash;
+  const hashIndex = pages.findIndex((page) => `#${page.hash}` === hash);
+  return hashIndex < 0 ? 0 : hashIndex;
 }

--- a/src/components/hash-router/useIntersect.ts
+++ b/src/components/hash-router/useIntersect.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from "react";
+import { useViewport, Viewport } from "./useViewport";
+
+/**
+ * Tracks intersecting state between an element and the viewport
+ * @param percentage percentage amount that the target needs to intersect with the viewport
+ * @return object with intersecting stateful value and a function to set/clear the target to track
+ */
+export const useIntersect = (
+  percentage: number = 1
+): {
+  intersecting: boolean;
+  setIntersectTarget: (el: Element | undefined) => void;
+} => {
+  const [intersecting, setIntersecting] = useState(false);
+  const [target, setTarget] = useState<Element>();
+  const viewport = useViewport();
+  const observer = useRef<IntersectionObserver>();
+
+  /**
+   * Whenever the target, viewport dimensions or required intersect percentage changes,
+   * set an observer for the target intersection with the viewport
+   */
+  useEffect(() => {
+    if (target) {
+      const threshold = maxIntersectThreshold(target, viewport) * percentage;
+      observer.current = new IntersectionObserver(
+        (entries) => setIntersecting(entries[0].isIntersecting),
+        { threshold: threshold }
+      );
+      observer.current?.observe(target);
+    }
+
+    return () => {
+      // clear observer and intersecting state
+      if (observer.current) {
+        observer.current.disconnect();
+        observer.current = undefined;
+      }
+      setIntersecting(false);
+    };
+  }, [percentage, target, viewport]);
+
+  return { intersecting, setIntersectTarget: setTarget };
+};
+
+/**
+ * Calculates the maximum intersect threshold an element can have with the viewport height.
+ * For elements with height <= viewport.height, the result will always be 1, since they can fit completely in the view
+ * @param element element to calculate maximum intersect threshold
+ * @param viewport viewport's dimensions
+ */
+function maxIntersectThreshold(element: Element, viewport: Viewport): number {
+  let boundingClientRect = element.getBoundingClientRect();
+  const elementHeight = boundingClientRect.bottom - boundingClientRect.top;
+  return elementHeight > viewport.height ? viewport.height / elementHeight : 1;
+}

--- a/src/components/hash-router/useViewport.ts
+++ b/src/components/hash-router/useViewport.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+const getViewport = (): Viewport => ({
+  width: window.innerWidth,
+  height: window.innerHeight,
+});
+
+/**
+ * Returns viewport stateful value
+ */
+export function useViewport(): Viewport {
+  const [viewport, setViewport] = useState(getViewport);
+
+  /**
+   * Listen to window's resize event, to set viewport value
+   */
+  useEffect(() => {
+    const handleResize = () => setViewport(getViewport());
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  });
+  return viewport;
+}


### PR DESCRIPTION
Observe each page section to identify when the user has scrolled to each one, based on the "active" or most prominent one, the window's hash is changed to that page's hash.

The functionality is implemented with the following changes

- Created `useViewport` hook: Reports the updated dimensions of the viewport
- Created `useIntersect`: Allows keeping track of a percentage intersection between an element and the viewport
- Created `Section` component. Used to render a page's content, while keeping track of its intersection with the viewport.
- Changed `HashRouter` to render Section  and react to their intersection with the viewport, whenever a section intersects with the viewport, the `window.location.hash` is changed to reflect the active page.

_Additionally, as cleanup: `useCallback` usage has been removed from `useHashIndex`._

[Change browser hash on scroll.webm](https://user-images.githubusercontent.com/5620143/208598083-f3c4c0d3-2651-4915-a042-6e4b2afd0cb2.webm)
