### PR TITLE
fix/Autoscroll interrupted by intersect observer

### DIFF
--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef } from "react";
 import useHashIndex from "./useHashIndex";
 import Section from "./Section";
 import { useScrollTo } from "./useScrollTo";
-import Navbar from "./Navbar";
 
 /**
  * A page element to displayed via {@link HashRouter}
@@ -28,22 +27,23 @@ type Props = {
  */
 export default function HashRouter({ pages }: Props) {
   const hashIndex = useHashIndex(pages);
-  const intersectingIndex = useRef(0);
   const mainRef = useRef<HTMLElement>(null);
   const { scrolling, scrollTo } = useScrollTo();
 
   /**
    * Scroll to section hashIndex section if it is not visible already
    */
-  useEffect(() => {
-    if (intersectingIndex.current !== hashIndex) {
-      scrollTo(mainRef.current?.children[hashIndex]);
-    }
-  }, [hashIndex]);
+  useEffect(
+    () => scrollTo(mainRef.current?.children[hashIndex]),
+    [hashIndex, scrollTo]
+  );
 
+  /**
+   * Change window hash when auto-scrolling is off and intersecting section != hashIndex
+   * @param index index of the intersecting section
+   */
   function handleIntersect(index: number) {
-    intersectingIndex.current = index;
-    if (index !== hashIndex && !scrolling) {
+    if (!scrolling && index !== hashIndex) {
       window.location.hash = pages[index].hash;
     }
   }

--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -28,15 +28,21 @@ type Props = {
  */
 export default function HashRouter({ pages }: Props) {
   const hashIndex = useHashIndex(pages);
+  const intersectingIndex = useRef(0);
   const mainRef = useRef<HTMLElement>(null);
   const { scrolling, scrollTo } = useScrollTo();
 
   /**
-   * Scroll to section whose index = hashIndex when it changes
+   * Scroll to section hashIndex section if it is not visible already
    */
-  useEffect(() => scrollTo(mainRef.current?.children[hashIndex]), [hashIndex]);
+  useEffect(() => {
+    if (intersectingIndex.current !== hashIndex) {
+      scrollTo(mainRef.current?.children[hashIndex]);
+    }
+  }, [hashIndex]);
 
   function handleIntersect(index: number) {
+    intersectingIndex.current = index;
     if (index !== hashIndex && !scrolling) {
       window.location.hash = pages[index].hash;
     }

--- a/src/components/hash-router/HashRouter.tsx
+++ b/src/components/hash-router/HashRouter.tsx
@@ -1,13 +1,19 @@
 import React, { useEffect, useRef } from "react";
 import useHashIndex from "./useHashIndex";
 import Section from "./Section";
+import { useScrollTo } from "./useScrollTo";
+import Navbar from "./Navbar";
 
 /**
  * A page element to displayed via {@link HashRouter}
  */
 export interface Page {
   /**
-   * page's anchor for hash navigation, without '#' character
+   * Label to use for links
+   */
+  label: string;
+  /**
+   * The page's anchor for hash navigation, without '#' character
    */
   hash: string;
   content: React.ReactNode;
@@ -23,20 +29,15 @@ type Props = {
 export default function HashRouter({ pages }: Props) {
   const hashIndex = useHashIndex(pages);
   const mainRef = useRef<HTMLElement>(null);
+  const { scrolling, scrollTo } = useScrollTo();
 
   /**
    * Scroll to section whose index = hashIndex when it changes
    */
-  useEffect(
-    () =>
-      mainRef.current?.children[hashIndex].scrollIntoView({
-        behavior: "smooth",
-      }),
-    [hashIndex]
-  );
+  useEffect(() => scrollTo(mainRef.current?.children[hashIndex]), [hashIndex]);
 
   function handleIntersect(index: number) {
-    if (index !== hashIndex) {
+    if (index !== hashIndex && !scrolling) {
       window.location.hash = pages[index].hash;
     }
   }

--- a/src/components/hash-router/HashRouterDemo.tsx
+++ b/src/components/hash-router/HashRouterDemo.tsx
@@ -38,7 +38,7 @@ const pages: Page[] = [
 export default function HashRouterDemo() {
   return (
     <>
-      <Navbar pages={pages} className="text-white" />
+      <Navbar pages={pages} className="bg-black text-white" />
       <HashRouter pages={pages} />
     </>
   );

--- a/src/components/hash-router/HashRouterDemo.tsx
+++ b/src/components/hash-router/HashRouterDemo.tsx
@@ -1,27 +1,31 @@
 import React from "react";
 import HashRouter, { Page } from "./HashRouter";
+import Navbar from "./Navbar";
 
 const pages: Page[] = [
   {
+    label: "Intro",
     hash: "intro",
     content: (
-      <div className="h-screen bg-pink-700 text-white text-4xl p-10">
+      <div className="h-screen bg-pink-700 text-white text-4xl p-20">
         Same height as the screen
       </div>
     ),
   },
   {
+    label: "Larger",
     hash: "larger",
     content: (
-      <div className="h-[140vh] bg-violet-700 text-white text-4xl p-10">
+      <div className="h-[140vh] bg-violet-700 text-white text-4xl p-20">
         Larger than the screen's height
       </div>
     ),
   },
   {
+    label: "Smaller",
     hash: "smaller",
     content: (
-      <div className="min-h-[55vh] bg-cyan-700 text-white text-4xl p-10">
+      <div className="min-h-[55vh] bg-cyan-700 text-white text-4xl p-20">
         Smaller than the screen's height
       </div>
     ),
@@ -32,5 +36,10 @@ const pages: Page[] = [
  * Simple hash router demo with basic pages
  */
 export default function HashRouterDemo() {
-  return <HashRouter pages={pages} />;
+  return (
+    <>
+      <Navbar pages={pages} className="text-white" />
+      <HashRouter pages={pages} />
+    </>
+  );
 }

--- a/src/components/hash-router/Navbar.tsx
+++ b/src/components/hash-router/Navbar.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Page } from "./HashRouter";
+import useHashIndex from "./useHashIndex";
+
+type Props = {
+  className?: string;
+  pages: Page[];
+};
+export default function Navbar({ className, pages }: Props) {
+  const hashIndex = useHashIndex(pages);
+  return (
+    <nav className={`w-full h-14 fixed top-0 left-0 z-10 ${className}`}>
+      <div className="container mx-auto h-full flex items-center px-2">
+        <div>HashRouter</div>
+        <div className="flex-1"></div>
+        <ul className="flex gap-4">
+          {pages.map((page, index) => (
+            <a
+              key={index}
+              href={`#${page.hash}`}
+              className={`${
+                index === hashIndex ? `border-b-2` : ""
+              } ${className}`}
+            >
+              {page.label}
+            </a>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/hash-router/Section.tsx
+++ b/src/components/hash-router/Section.tsx
@@ -34,7 +34,9 @@ export default function Section({ className = "", onIntersect, page }: Props) {
     if (intersecting) {
       onIntersect();
     }
-  }, [intersecting, setIntersectTarget]);
+    // exclude onIntersect from deps, so it doesn't report the same intersecting state every time the parent is render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [intersecting]);
 
   return (
     <section ref={sectionRef} className={className}>

--- a/src/components/hash-router/Section.tsx
+++ b/src/components/hash-router/Section.tsx
@@ -25,7 +25,7 @@ export default function Section({ className = "", onIntersect, page }: Props) {
     if (sectionRef.current) {
       setIntersectTarget(sectionRef.current);
     }
-  }, []);
+  }, [setIntersectTarget]);
 
   /**
    * When section is intersecting, notify the parent
@@ -34,7 +34,7 @@ export default function Section({ className = "", onIntersect, page }: Props) {
     if (intersecting) {
       onIntersect();
     }
-  }, [intersecting]);
+  }, [intersecting, setIntersectTarget]);
 
   return (
     <section ref={sectionRef} className={className}>

--- a/src/components/hash-router/Section.tsx
+++ b/src/components/hash-router/Section.tsx
@@ -16,7 +16,7 @@ type Props = {
  */
 export default function Section({ className = "", onIntersect, page }: Props) {
   const sectionRef = useRef(null);
-  const { intersecting, setIntersectTarget } = useIntersect(0.99);
+  const { intersecting, setIntersectTarget } = useIntersect(0.9);
 
   /**
    * Set section as intersecting target
@@ -25,7 +25,7 @@ export default function Section({ className = "", onIntersect, page }: Props) {
     if (sectionRef.current) {
       setIntersectTarget(sectionRef.current);
     }
-  }, [setIntersectTarget]);
+  }, []);
 
   /**
    * When section is intersecting, notify the parent
@@ -34,7 +34,7 @@ export default function Section({ className = "", onIntersect, page }: Props) {
     if (intersecting) {
       onIntersect();
     }
-  }, [intersecting, onIntersect]);
+  }, [intersecting]);
 
   return (
     <section ref={sectionRef} className={className}>

--- a/src/components/hash-router/useIntersect.ts
+++ b/src/components/hash-router/useIntersect.ts
@@ -28,7 +28,7 @@ export const useIntersect = (percentage: number = 1): IntersectObject => {
   const observer = useRef<IntersectionObserver>();
 
   /**
-   * Whenever the target, viewport dimensions or required intersect percentage changes,
+   * Whenever the target, viewport or intersect percentage changes,
    * set an observer for the target intersection with the viewport
    */
   useEffect(() => {

--- a/src/components/hash-router/useIntersect.ts
+++ b/src/components/hash-router/useIntersect.ts
@@ -1,17 +1,27 @@
 import { useEffect, useRef, useState } from "react";
 import { useViewport, Viewport } from "./useViewport";
 
+export interface IntersectObject {
+  /**
+   * Current element being tracked for intersection with the viewport
+   */
+  target: Element | undefined;
+  /**
+   * Whether the current target is intersecting with the viewport
+   */
+  intersecting: boolean;
+  /**
+   * Change element to track intersection with the viewport
+   * @param el new element to track or undefined to clear it
+   */
+  setIntersectTarget: (el: Element | undefined) => void;
+}
+
 /**
  * Tracks intersecting state between an element and the viewport
  * @param percentage percentage amount that the target needs to intersect with the viewport
- * @return object with intersecting stateful value and a function to set/clear the target to track
  */
-export const useIntersect = (
-  percentage: number = 1
-): {
-  intersecting: boolean;
-  setIntersectTarget: (el: Element | undefined) => void;
-} => {
+export const useIntersect = (percentage: number = 1): IntersectObject => {
   const [intersecting, setIntersecting] = useState(false);
   const [target, setTarget] = useState<Element>();
   const viewport = useViewport();
@@ -41,7 +51,7 @@ export const useIntersect = (
     };
   }, [percentage, target, viewport]);
 
-  return { intersecting, setIntersectTarget: setTarget };
+  return { target, intersecting, setIntersectTarget: setTarget };
 };
 
 /**

--- a/src/components/hash-router/useScrollTo.ts
+++ b/src/components/hash-router/useScrollTo.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useIntersect } from "./useIntersect";
+
+export function useScrollTo(): {
+  scrolling: boolean;
+  scrollTo: (el: Element | undefined) => void;
+} {
+  const { target, intersecting, setIntersectTarget } = useIntersect(0.1);
+
+  /**
+   * Once target is intersecting, clear it
+   */
+  useEffect(() => {
+    if (intersecting) {
+      setIntersectTarget(undefined);
+    }
+  }, [intersecting]);
+
+  /**
+   * Sets scroll target
+   * @param el element to scroll to, clears the target if provided value is null
+   */
+  function scrollTo(el: Element | undefined) {
+    setIntersectTarget(el);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth" });
+    }
+  }
+
+  return { scrolling: target !== undefined, scrollTo: scrollTo };
+}

--- a/src/components/hash-router/useScrollTo.ts
+++ b/src/components/hash-router/useScrollTo.ts
@@ -1,11 +1,32 @@
 import { useEffect } from "react";
 import { useIntersect } from "./useIntersect";
 
-export function useScrollTo(): {
+interface ScrollObject {
+  /**
+   * Stateful value of scrolling state to element target
+   */
   scrolling: boolean;
+  /**
+   * Set scroll's target
+   * @param el element to scroll to, or undefined to clear it
+   */
   scrollTo: (el: Element | undefined) => void;
-} {
+}
+
+/**
+ * Scrolls into one element at a time and notify when scrolling ends
+ */
+export function useScrollTo(): ScrollObject {
   const { target, intersecting, setIntersectTarget } = useIntersect(0.1);
+
+  /**
+   * Once a target is set, scroll to it
+   */
+  useEffect(() => {
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [target]);
 
   /**
    * Once target is intersecting, clear it
@@ -14,18 +35,7 @@ export function useScrollTo(): {
     if (intersecting) {
       setIntersectTarget(undefined);
     }
-  }, [intersecting]);
+  }, [intersecting, setIntersectTarget]);
 
-  /**
-   * Sets scroll target
-   * @param el element to scroll to, clears the target if provided value is null
-   */
-  function scrollTo(el: Element | undefined) {
-    setIntersectTarget(el);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth" });
-    }
-  }
-
-  return { scrolling: target !== undefined, scrollTo: scrollTo };
+  return { scrolling: target !== undefined, scrollTo: setIntersectTarget };
 }


### PR DESCRIPTION
### Fix the issue that stops auto-scrolling when a section in the middle is intercepted

Description

- Render hash router with at least 3 pages
- start with the hash router displaying the first page
- change the window hash to point to the last page, using a navbar with links helps to make the testing faster

Expected result: 
- The view should scroll to the last page

Actual result:
- The scrolling stops once it gets to the second section, see the video

[Bug_stopping_auto_scrolling.webm](https://user-images.githubusercontent.com/5620143/209171286-3ebfffcb-1c3d-4cfe-b6cb-894decfd57c8.webm)

---

### Solution

The issue happens because, while the view is scrolling to the last section, the middle section identifies it has intersected with the viewport and notifies HashRouter. HashRouter then changes the hash to the middle section.
It is required a way to stop processing section intersecting events while auto-scroll is in progress.

### Changes

- Added a `Navbar` component: simple navigation to test the bug easier.
- Included `Navbar` in the `HashRouterDemo` component.
- Created hook `useScrollTo`: it allows to scroll to an element at a time and reports whenever the scrolling has ended.
- `HashRouter` uses `useScrollTo` to scroll to the active section, and ignores section intersect events while auto-scrolling is in place
- Improve `Section` and `useIntersect` comments.

